### PR TITLE
Add session management panel with delete support

### DIFF
--- a/css/live-captioning.css
+++ b/css/live-captioning.css
@@ -151,12 +151,81 @@ li {
   width: 300px;
 }
 
-#lc-sessions {  
+#lc-sessions {
   margin-bottom: 2em;
   margin-top: 2em;
 }
 
-#lc-session-types { 
+#session-list {
+  max-width: 500px;
+  margin: 0 auto 1em;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  overflow: hidden;
+  text-align: left;
+}
+
+.session-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65em 1em;
+  border-bottom: 1px solid #ddd;
+  background: #f9f9f9;
+  cursor: pointer;
+}
+
+.session-item:last-child {
+  border-bottom: none;
+}
+
+.session-item:hover {
+  background: #e8e8e8;
+}
+
+.session-item.selected {
+  background: #595959;
+  color: #fff;
+}
+
+.session-info {
+  flex: 1;
+}
+
+.session-name {
+  font-weight: bold;
+  display: block;
+}
+
+.session-date {
+  font-size: 0.82em;
+  color: #777;
+}
+
+.session-item.selected .session-date {
+  color: #ccc;
+}
+
+.session-delete-btn {
+  padding: 5px 10px;
+  font-size: 12px;
+  margin-bottom: 0;
+  background: #8b0000;
+  border-color: #6b0000;
+  text-shadow: none;
+  flex-shrink: 0;
+}
+
+.session-delete-btn:hover,
+.session-delete-btn:focus {
+  background: #6b0000;
+}
+
+#session-actions {
+  margin-bottom: 1em;
+}
+
+#lc-session-types {
   text-align: right;
 }
 

--- a/index.html
+++ b/index.html
@@ -100,18 +100,19 @@
     </div>
   </section>
   <section id="lc-sessions">
-    <label for="session-select">Choose a Session</label><select id="session-select"></select>
-    <div id="session-continue"><button class="lc-btn lc-btn-wide" onclick="continueSession(event)">Continue selected session</button></div>
-    <div id="session-view"><button class="lc-btn lc-btn-wide" onclick="viewSession()">View selected session transcript</button></div>
-    <div id="lc-transcript">
-          <div><textarea></textarea><div>
-          <div id="lc-session-types">
-            <span id="session-view"><button class="lc-btn" onclick="viewSession('srt')">SRT</button></span>          
-            <span id="session-view"><button class="lc-btn" onclick="viewSession('webVTT')">WebVTT</button></span>
-            <span id="session-view"><button class="lc-btn" onclick="viewSession('text')">Text</button></span>
-          </div>
+    <div id="session-list"></div>
+    <div id="session-actions">
+      <button class="lc-btn lc-btn-wide" onclick="continueSession(event)">Continue selected session</button>
+      <button class="lc-btn lc-btn-wide" onclick="viewSession()">View selected session transcript</button>
     </div>
-
+    <div id="lc-transcript">
+      <div><textarea></textarea></div>
+      <div id="lc-session-types">
+        <button class="lc-btn" onclick="viewSession('srt')">SRT</button>
+        <button class="lc-btn" onclick="viewSession('webVTT')">WebVTT</button>
+        <button class="lc-btn" onclick="viewSession('text')">Text</button>
+      </div>
+    </div>
   </section>
   <footer>
     <a href="https://github.com/MidCamp/live-captioning?tab=readme-ov-file#live-captioning">View this project on Github</a>

--- a/js/live-captioning.js
+++ b/js/live-captioning.js
@@ -3,6 +3,7 @@ var lc = document.getElementById('lc-text');
 var button = document.getElementById('lc-button');
 
 var recognizing = false;
+var selectedSession = null;
 
 var recognition = new webkitSpeechRecognition();
 var sessions = loadFromLocalStorage('sessions');
@@ -24,6 +25,7 @@ languageSelector.addEventListener('change', function() {
 if (! sessions){
   sessions = [];
   $('#lc-rec').hide();
+  $('#lc-sessions').hide();
 } else {
   showRecordings();
 }
@@ -73,6 +75,7 @@ function toggleSpeechRecognition(event) {
     lc.firstChild.data = "Begin speaking. Click to stop.";
     button.style.display = "inline-block";    
     $('body').removeClass('lc-on');
+    selectedSession = currentSession;
     showRecordings();
     return;
   } else {
@@ -133,47 +136,84 @@ function locationHashChanged() {
 }
 
 
-function showRecordings (){
-  // Populate and show recordings section - maybe only if they're on a page with a hash tag
-  
-  var select = document.getElementById('session-select');
-  
-  // Clear any existing options, since we're refreshing after recording
-  for(i = select.options.length - 1 ; i >= 0 ; i--){
-    select.remove(i);
+function showRecordings() {
+  $('#lc-sessions').show();
+  $('#lc-rec').show();
+  var list = document.getElementById('session-list');
+  list.innerHTML = '';
+
+  for (var i = 0; i < sessions.length; i++) {
+    var session = sessions[i];
+    var date = new Date(session.startTime);
+    var dateStr = date.toLocaleDateString([], {year: 'numeric', month: 'short', day: 'numeric'}) +
+                  ' ' + date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+
+    var item = document.createElement('div');
+    item.className = 'session-item' + (selectedSession === i ? ' selected' : '');
+    item.setAttribute('data-index', i);
+    item.innerHTML =
+      '<div class="session-info" onclick="selectSession(' + i + ')">' +
+        '<span class="session-name">' + session.name + '</span>' +
+        '<span class="session-date">' + dateStr + '</span>' +
+      '</div>' +
+      '<button class="lc-btn session-delete-btn" onclick="deleteSession(event, ' + i + ')">Delete</button>';
+
+    list.appendChild(item);
   }
-  
-  for(index in sessions) {
-      select.options[select.options.length] = new Option(sessions[index].name, index);
+
+  if (selectedSession === null && sessions.length > 0) {
+    var initialIndex = window.location.hash ? findSessionFromHash() : null;
+    selectSession(initialIndex !== null ? initialIndex : 0);
   }
-  if (window.location.hash){
-    var selectValue = findSessionFromHash();
-    if (selectValue){
-      select.value = selectValue;
+}
+
+function selectSession(index) {
+  selectedSession = index;
+  var items = document.querySelectorAll('.session-item');
+  for (var i = 0; i < items.length; i++) {
+    var itemIndex = parseInt(items[i].getAttribute('data-index'));
+    items[i].classList.toggle('selected', itemIndex === index);
+  }
+}
+
+function deleteSession(event, index) {
+  event.stopPropagation();
+  localStorage.removeItem(sessions[index].name);
+  sessions.splice(index, 1);
+  saveToLocalStorage('sessions', sessions);
+
+  if (sessions.length === 0) {
+    selectedSession = null;
+    $('#lc-sessions').hide();
+    $('#lc-rec').hide();
+  } else {
+    if (selectedSession > index) {
+      selectedSession--;
+    } else if (selectedSession >= sessions.length) {
+      selectedSession = sessions.length - 1;
     }
+    showRecordings();
   }
-
-
-  select.style = "";
 }
 
 function continueSession(event){
-  var select = document.getElementById('session-select');
-  currentSession = select.value;
+  if (selectedSession === null) return;
+  currentSession = selectedSession;
   toggleSpeechRecognition(event);
 }
 
 function viewSession(format) {
-  var select = document.getElementById('session-select');
+  if (selectedSession === null) return;
+  var session = sessions[selectedSession];
   var textArea = $('#lc-transcript textarea')[0];
   switch(format){
     case "text":
-      textArea.value = formatTranscriptText(loadFromLocalStorage(sessions[select.value].name));
+      textArea.value = formatTranscriptText(loadFromLocalStorage(session.name));
       break;
     case "srt":
     case "webVTT":
     default:
-      textArea.value = formatTranscriptTimeStamped(loadFromLocalStorage(sessions[select.value].name), sessions[select.value].startTime, format);
+      textArea.value = formatTranscriptTimeStamped(loadFromLocalStorage(session.name), session.startTime, format);
       break;
   }
   if (format){


### PR DESCRIPTION
## Summary

- Replaces the session `<select>` dropdown with a styled list panel showing each session's name and formatted start date/time
- Each row has a **Delete** button that removes the session from localStorage (both metadata and transcript) and re-renders the list
- Clicking a row selects it (highlighted in dark); the most recently recorded session is auto-selected when recording stops
- The sessions panel hides itself when no sessions exist and re-appears after the first recording

## What changed

- **`index.html`** — replaced `<select id="session-select">` with `<div id="session-list">` (dynamically populated); fixed duplicate `id="session-view"` attributes and a malformed `</div>` tag in `#lc-transcript`
- **`js/live-captioning.js`** — added `selectedSession` variable; new `showRecordings()` builds a DOM list instead of `<option>` elements; new `selectSession(index)` and `deleteSession(event, index)` functions; updated `continueSession` and `viewSession` to use `selectedSession` instead of `select.value`
- **`css/live-captioning.css`** — styles for the session list panel, hover/selected states, and the delete button

## Reviewer notes

- No backend changes — all data remains in `localStorage`
- Behaviour on Chrome is unchanged; the Web Speech API integration is untouched
- The `lc-on` CSS class that hides `#lc-sessions` during live captioning is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)